### PR TITLE
Swap |° with <> keys

### DIFF
--- a/Latam.keylayout
+++ b/Latam.keylayout
@@ -44,7 +44,7 @@
 			<key code="7" output="x"/>
 			<key code="8" output="c"/>
 			<key code="9" output="v"/>
-			<key code="10" output="&#x003C;"/>
+			<key code="10" output="|"/>
 			<key code="11" output="b"/>
 			<key code="12" output="q"/>
 			<key code="13" output="w"/>
@@ -84,7 +84,7 @@
 			<key code="47" output="."/>
 			<key code="48" output="&#x0009;"/>
 			<key code="49" action="a20"/>
-			<key code="50" output="|"/>
+			<key code="50" output="&#x003C;"/>
 			<key code="51" output="&#x0008;"/>
 			<key code="52" output="&#x0003;"/>
 			<key code="53" output="&#x001B;"/>
@@ -282,7 +282,7 @@
 			<key code="7" output="X"/>
 			<key code="8" output="C"/>
 			<key code="9" output="V"/>
-			<key code="10" output="&#x003C;"/>
+			<key code="10" output="|"/>
 			<key code="11" output="B"/>
 			<key code="12" output="Q"/>
 			<key code="13" output="W"/>
@@ -322,7 +322,7 @@
 			<key code="47" output="."/>
 			<key code="48" output="&#x0009;"/>
 			<key code="49" action="a20"/>
-			<key code="50" output="|"/>
+			<key code="50" output="&#x003C;"/>
 			<key code="51" output="&#x0008;"/>
 			<key code="52" output="&#x0003;"/>
 			<key code="53" output="&#x001B;"/>
@@ -547,7 +547,7 @@
 			<key code="25" output="·"/>
 			<key code="26" output="‡"/>
 			<key code="27" output="—"/>
-			<key code="28" output="°"/>
+			<key code="28" output="&#x003E;"/>
 			<key code="29" output="‚"/>
 			<key code="30" output="’"/>
 			<key code="31" output="Ø"/>


### PR DESCRIPTION
Not sure if something's missing because I don't know anything about key mapping in Mac. However, I noticed that for Type A keyboard (external type), the `|` was swapped with the `<` key.

In other words:
* Pressing `<` produced `|`. 
* Pressing `shift` + `<` produced `°`

And:
* Pressing `|` produced `<`
* Pressing `shift` + `|` produced `>`

Changing the mapping like this now matches what I see on my keyboard and what I actually have on my physical external LATAM keyboard.